### PR TITLE
Add fuzzer infrastructure

### DIFF
--- a/fuzzing/build.sh
+++ b/fuzzing/build.sh
@@ -1,0 +1,1 @@
+AFL_HARDEN=1 afl/afl-clang-fast fuzz.c -O2 -o fuzz

--- a/fuzzing/fuzz.c
+++ b/fuzzing/fuzz.c
@@ -1,0 +1,29 @@
+#define MINIMP3_IMPLEMENTATION
+#include "../minimp3.h"
+#include <stdio.h>
+
+int main()
+{
+    static mp3dec_t mp3d;
+    mp3dec_frame_info_t info;
+    int nbuf = 0;
+    unsigned char buf[4096];
+
+    mp3dec_init(&mp3d);
+
+#ifdef __AFL_HAVE_MANUAL_CONTROL
+	__AFL_INIT();
+    while (__AFL_LOOP(1000))
+#endif
+	{
+		do
+	    {
+	        short pcm[MINIMP3_MAX_SAMPLES_PER_FRAME];
+        	nbuf += fread(buf + nbuf, 1, sizeof(buf) - nbuf, stdin);
+	        mp3dec_decode_frame(&mp3d, buf, nbuf, pcm, &info);
+			nbuf -= info.frame_bytes;
+	    } while (info.frame_bytes);
+	}
+
+    return 0;
+}

--- a/fuzzing/fuzz.sh
+++ b/fuzzing/fuzz.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+cd "${0%/*}"
+
+afl/afl-fuzz -m 50 -i- -o findings/ ./fuzz

--- a/fuzzing/get-afl.sh
+++ b/fuzzing/get-afl.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+cd "${0%/*}"
+rm afl-latest.tgz
+wget http://lcamtuf.coredump.cx/afl/releases/afl-latest.tgz || exit
+tar -xzvf afl-latest.tgz
+rm afl-latest.tgz
+cd afl-*
+make || exit
+cd llvm_mode
+# may need to prepend LLVM_CONFIG=/usr/bin/llvm-config-3.8 or similar, depending on the system
+make || exit
+cd ../libdislocator
+make || exit
+cd ../..
+rm -rf afl
+mv afl-* afl

--- a/fuzzing/get-afl.sh
+++ b/fuzzing/get-afl.sh
@@ -9,8 +9,6 @@ make || exit
 cd llvm_mode
 # may need to prepend LLVM_CONFIG=/usr/bin/llvm-config-3.8 or similar, depending on the system
 make || exit
-cd ../libdislocator
-make || exit
 cd ../..
 rm -rf afl
 mv afl-* afl


### PR DESCRIPTION
As per #11, this adds fuzzer infrastructure in a separate tiny program, to avoid polluting the minimp3 example file even more. I don't think it makes sense to put the fuzzer stuff there, because it will also fuzz completely unrelated code, and it might confuse people who just want to have a quick look at how to use the library.
There are scripts to automatically download the latest AFL, to compile the testcase using afl-clang-fast and to launch the fuzzer. You may want to add some more flags to fuzz.sh for ASAN, UBSAN, etc, I left those out in my original tests.