### PR TITLE
Fix VC++ compilation error for non-x86/64 targets.

### DIFF
--- a/minimp3.h
+++ b/minimp3.h
@@ -89,7 +89,7 @@ int mp3dec_decode_frame(mp3dec_t *dec, const unsigned char *mp3, int mp3_bytes, 
 #define MINIMP3_ONLY_SIMD
 #endif
 
-#if defined(_MSC_VER) || ((defined(__i386__) || defined(__x86_64__)) && defined(__SSE2__))
+#if (defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))) || ((defined(__i386__) || defined(__x86_64__)) && defined(__SSE2__))
 #if defined(_MSC_VER)
 #include <intrin.h>
 #endif


### PR DESCRIPTION
Visual C++ supports ARM. x86/x64 needs to be explicitly checked before enabling SSE.