### PR TITLE
added option to decode headers only

### DIFF
--- a/minimp3.h
+++ b/minimp3.h
@@ -1645,6 +1645,11 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, short 
     info->layer = 4 - HDR_GET_LAYER(hdr);
     info->bitrate_kbps = hdr_bitrate_kbps(hdr);
 
+    if (!pcm)
+    {
+        return hdr_frame_samples(hdr);
+    }
+
     bs_init(bs_frame, hdr + HDR_SIZE, frame_size - HDR_SIZE);
     if (HDR_IS_CRC(hdr))
     {


### PR DESCRIPTION
If the 'pcm' parameter to mp3dec_decode_frame()
is set to NULL, all bitstream and audio decoding
is skipped, but the header is still decoded and
frame info is still generated.

This is useful for quickly scanning an MP3 file,
e.g. to determine the duration or generate a
VBR seek index.