### PR TITLE
Fix inconsistency of `size_t` => `int` for mp3dec_iterate_w

### DIFF
--- a/minimp3_ex.h
+++ b/minimp3_ex.h
@@ -1217,7 +1217,7 @@ int mp3dec_load_w(mp3dec_t *dec, const wchar_t *file_name, mp3dec_file_info_t *i
     return mp3dec_load_mapinfo(dec, &map_info,info, progress_cb, user_data);
 }
 
-size_t mp3dec_iterate_w(const wchar_t *file_name, MP3D_ITERATE_CB callback, void *user_data)
+int mp3dec_iterate_w(const wchar_t *file_name, MP3D_ITERATE_CB callback, void *user_data)
 {
     int ret;
     mp3dec_map_info_t map_info;


### PR DESCRIPTION
This PR fixes an inconsistency of `size_t` => `int` for mp3dec_iterate_w.
On Windows size_t and int may not match so the following might arise depending
on Configuration:
```
error C2556: 'size_t mp3dec_iterate_w(const wchar_t *,MP3D_ITERATE_CB,void *)': overloaded function differs only by return type from 'int mp3dec_iterate_w(const wchar_t *,MP3D_ITERATE_CB,void *)'
```

This fix fixes the issue

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>