### PR TITLE
Don't return error from mp3dec_ex_read()

### DIFF
--- a/minimp3_ex.h
+++ b/minimp3_ex.h
@@ -844,8 +844,6 @@ do_exit:
 
 size_t mp3dec_ex_read(mp3dec_ex_t *dec, mp3d_sample_t *buf, size_t samples)
 {
-    if (!dec || !buf)
-        return MP3D_E_PARAM;
     uint64_t end_offset = dec->end_offset ? dec->end_offset : dec->file.size;
     size_t samples_requested = samples;
     int eof = 0;


### PR DESCRIPTION
Aren't those pointers just assumed to be non-NULL?

I'm not sure whether it's necessary to check for this, but if it is checked, the result should not be returned as "number of successfully read samples".

`MP3D_E_PARAM` is defined as `-1`, so if you assign it to a `size_t`, I guess it becomes a huge value which could be interpreted as the number of samples that have been read.

Or am I missing something?