### PR TITLE
Don't check MINIMP3_ALLOW_MONO_STEREO_TRANSITION in mp3dec_ex_read()

### DIFF
--- a/minimp3_ex.h
+++ b/minimp3_ex.h
@@ -898,9 +898,7 @@ size_t mp3dec_ex_read_frame(mp3dec_ex_t *dec, mp3d_sample_t **buf, size_t max_sa
         }
         dec->buffer_consumed = 0;
         if (dec->info.hz != frame_info.hz || dec->info.layer != frame_info.layer
-#ifndef MINIMP3_ALLOW_MONO_STEREO_TRANSITION
             || dec->info.channels != frame_info.channels
-#endif
             )
         {
             dec->last_error = MP3D_E_DECODE;


### PR DESCRIPTION
I might be missing something, but given the current API, ever allowing mono-stereo transitions in `mp3dec_ex_read()` doesn't really make any sense, right?

If we were to allow it, this would mean in the output buffer of `mp3dec_ex_read()` there could be a transition at any time, and we don't know where it is.
So we don't know if we should treat the buffer as interleaved or not, or even worse, as partially interleaved.

Since we now have a `mp3dec_ex_read_frame()` function, we could try to handle this situation, but we would still need a change in the current API.

Theoretically `mp3dec_ex_read_frame()` could return the number of channels for each decoded frame.
I guess this would be possible to implement, but `mp3dec_ex_seek()` would have to be taken into account.
After each seek operation, the current frame's number of channels would have to be stored somewhere in order to be provided to `mp3dec_ex_read_frame()`.

I don't know how common mixed mono/stereo MP3s are, probably they are not worth having a more complicated API?

See also #74.