### PR TITLE
Fail when playing back in invalid file.

### DIFF
--- a/minimp3.h
+++ b/minimp3.h
@@ -1690,6 +1690,9 @@ static int mp3d_find_frame(const uint8_t *mp3, int mp3_bytes, int *free_format_b
             }
             *free_format_bytes = 0;
         }
+        else {
+            break;
+        }
     }
     *ptr_frame_bytes = 0;
     return mp3_bytes;


### PR DESCRIPTION
I'm not sure if this would cause issues but in my library I need minimp3 to fail if an invalid file is specified.

If there is a better way to do this please let me know, otherwise feel free to merge.