### PR TITLE
Don't enable ARMv6 features for ARMv6-m

### DIFF
--- a/minimp3.h
+++ b/minimp3.h
@@ -191,7 +191,7 @@ static int have_simd()
 #define HAVE_SIMD 0
 #endif /* !defined(MINIMP3_NO_SIMD) */
 
-#if defined(__ARM_ARCH) && (__ARM_ARCH >= 6) && !defined(__aarch64__) && !defined(_M_ARM64)
+#if defined(__ARM_ARCH) && (__ARM_ARCH >= 6) && !defined(__aarch64__) && !defined(_M_ARM64) && !defined(__ARM_ARCH_6M__)
 #define HAVE_ARMV6 1
 static __inline__ __attribute__((always_inline)) int32_t minimp3_clip_int16_arm(int32_t a)
 {


### PR DESCRIPTION
The existing check for ARMv6 and greater matches on ARMv6-m.
This causes build failures on cortex-m0 and cortex-m0+ as they do not support the ssat instruction.

This is what the problematic code in minimp3.h looks like:
```C
#if defined(__ARM_ARCH) && (__ARM_ARCH >= 6) && !defined(__aarch64__) && !defined(_M_ARM64)
#define HAVE_ARMV6 1
static __inline__ __attribute__((always_inline)) int32_t minimp3_clip_int16_arm(int32_t a)
{
    int32_t x = 0;
    __asm__ ("ssat %0, #16, %1" : "=r"(x) : "r"(a));
    return x;
}
#else
#define HAVE_ARMV6 0
#endif
```
when compiled for -armv6-m or -armv6s-m you get

```console
$ arm-none-eabi-gcc -O3  -ffunction-sections -fdata-sections -g -fno-omit-frame-pointer -mthumb -march=armv6s-m -I minimp3 -Wall -Wextra -DMINIMP3_NO_SIMD -DMINIMP3_ONLY_MP3 -DMINIMP3_IMPLEMENTATION -o /home/9names/soundtest/minimp3/minimp3.o -c minimp3/minimp3.c
/tmp/ccsTu1My.s: Assembler messages:
/tmp/ccsTu1My.s:3095: Error: selected processor does not support `ssat r0,#16,r0' in Thumb mode
/tmp/ccsTu1My.s:3284: Error: selected processor does not support `ssat r3,#16,r3' in Thumb mode
/tmp/ccsTu1My.s:18200: Error: selected processor does not support `ssat r0,#16,r0' in Thumb mode
/tmp/ccsTu1My.s:18565: Error: selected processor does not support `ssat r0,#16,r0' in Thumb mode
/tmp/ccsTu1My.s:18920: Error: selected processor does not support `ssat r0,#16,r0' in Thumb mode
/tmp/ccsTu1My.s:19279: Error: selected processor does not support `ssat r0,#16,r0' in Thumb mode
/tmp/ccsTu1My.s:19635: Error: selected processor does not support `ssat r0,#16,r0' in Thumb mode
/tmp/ccsTu1My.s:19989: Error: selected processor does not support `ssat r0,#16,r0' in Thumb mode
/tmp/ccsTu1My.s:20341: Error: selected processor does not support `ssat r0,#16,r0' in Thumb mode
/tmp/ccsTu1My.s:20699: Error: selected processor does not support `ssat r0,#16,r0' in Thumb mode

selected processor does not support `ssat r0,#16,r0' in Thumb mode
```

Adding the additional check that `__ARM_ARCH_6M__` is not present in the #ifdef chain solves this issue, and as this is only present on cortex-m0/cortex-m0+ processors it should not break any other targets.