### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,20 @@ As a special case, the decoder supports already split MP3 streams (for example,
 after doing an MP4 demux). In this case, the input buffer must contain _exactly
 one_ non-free-format frame.
 
+## Installing minimp3 (vcpkg)
+
+Alternatively, you can build and install minimp3 using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+```sh or powershell
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh # "./bootstrap-vcpkg.bat" for powershell
+    ./vcpkg integrate install
+    ./vcpkg install minimp3
+```
+
+The minimp3 port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Seeking
 
 You can seek to any byte in the stream and call ``mp3dec_decode_frame``; this


### PR DESCRIPTION
`minimp3` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `minimp3` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `minimp3`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/minimp3/portfile.cmake). We try to keep the library maintained as close as possible to the original library. :)