### PR TITLE
Fix unsigned integer underflow in mp3dec_ex_read_frame leading to heap buffer overflow

### DIFF
--- a/minimp3_ex.h
+++ b/minimp3_ex.h
@@ -936,6 +936,8 @@ size_t mp3dec_ex_read_frame(mp3dec_ex_t *dec, mp3d_sample_t **buf, mp3dec_frame_
             dec->input_consumed += frame_info->frame_bytes;
         } else
         {
+            if (dec->offset >= end_offset)
+                return 0;
             dec_buf = dec->file.buffer + dec->offset;
             uint64_t buf_size = end_offset - dec->offset;
             if (!buf_size)


### PR DESCRIPTION
## Description

This PR fixes an unsigned integer underflow condition in `mp3dec_ex_read_frame` within `minimp3_ex.h`.

During analysis of a malformed MP3 file, I observed a state where:

```text
end_offset = 192
dec->offset = 274
```

The remaining buffer size is calculated as:

```c
uint64_t buf_size = end_offset - dec->offset;
```

Because no validation is performed before the subtraction, this results in an unsigned integer underflow and produces an unexpectedly large `buf_size` value.

The underflow condition was observed together with a reproducible AddressSanitizer-reported heap out-of-bounds read during frame decoding.

## Root Cause

```c
uint64_t buf_size = end_offset - dec->offset;
```

If `dec->offset > end_offset`, the subtraction underflows.

## Proposed Fix

```c
if (dec->offset >= end_offset)
    return 0;
```

This prevents the underflow condition before the buffer size calculation.

## Impact

This fix prevents malformed input from triggering the underflow condition and avoids passing an invalid buffer range into the decoding path.
